### PR TITLE
Change Image.fromstring to Image.frombytes as fromstring function has…

### DIFF
--- a/modules/picty/imagemanip.py
+++ b/modules/picty/imagemanip.py
@@ -660,9 +660,9 @@ def load_image(item,collection,interrupt_fn,draft_mode=False,apply_transforms=Tr
                 width,height = image_pb.get_width(),image_pb.get_height()
                 if image_pb.get_n_channels() >=3:
                     if image_pb.get_has_alpha():
-                        image=Image.fromstring("RGBA",(width,height),image_pb.get_pixels() )
+                        image=Image.frombytes("RGBA",(width,height),image_pb.get_pixels() )
                     else:
-                        image=Image.fromstring("RGB",(width,height),image_pb.get_pixels() )
+                        image=Image.frombytes("RGB",(width,height),image_pb.get_pixels() )
                 else:
                     print "GDK Parser - Can't handle image with less than 3 channel"
                     raise TypeError
@@ -754,7 +754,7 @@ def pixbuf_to_image(pb):
     ch = pb.get_n_channels()
 
     width,height = pb.get_width(),pb.get_height()
-    image = Image.fromstring("RGB",(width,height),pb.get_pixels() )
+    image = Image.frombytes("RGB",(width,height),pb.get_pixels() )
 
     return image
 

--- a/modules/picty/viewsupport.py
+++ b/modules/picty/viewsupport.py
@@ -379,6 +379,11 @@ class DateCompare:
 def contains_tag(l,r,item):
     try:
         text=r.strip()
+        if text ='' and 'Keywords' not in item.meta:
+            item.relevance+=3
+        if text == '' and item.meta['Keywords'] == None:
+            item.relevance+=3
+            return True
         if text in item.meta['Keywords']:
             item.relevance+=3
             return True


### PR DESCRIPTION
… been removed.

When I ran picty, some images would only show in thumbnail, not in image viewer or full screen. The command prompt reported an error from the Image.fromstring command not existing any more and saying that frombytes should be used instead. I made that change and this fixed my issue viewing files.